### PR TITLE
Load null pointer exception fix

### DIFF
--- a/src/main/java/com/telq/sdk/TelQTestClient.java
+++ b/src/main/java/com/telq/sdk/TelQTestClient.java
@@ -1,5 +1,6 @@
 package com.telq.sdk;
 
+import com.google.gson.Gson;
 import com.telq.sdk.model.TelQUrls;
 import com.telq.sdk.model.authorization.ApiCredentials;
 import com.telq.sdk.model.network.DestinationNetwork;
@@ -287,7 +288,9 @@ public class TelQTestClient {
         if(resultsCallBackToken != null)
             request.setHeader("results-callback-token", resultsCallBackToken);
 
-        request.setEntity(new StringEntity(JsonMapper.getInstance().getMapper().toJson(requestTestDto)));
+        Gson mapper = JsonMapper.getInstance().getMapper();
+        StringEntity bodyEntity = new StringEntity(mapper.toJson(requestTestDto));
+        request.setEntity(bodyEntity);
 
         return request;
     }

--- a/src/main/java/com/telq/sdk/utils/JsonMapper.java
+++ b/src/main/java/com/telq/sdk/utils/JsonMapper.java
@@ -15,7 +15,7 @@ public class JsonMapper {
     private JsonMapper() {
     }
 
-    public static JsonMapper getInstance() {
+    public synchronized static JsonMapper getInstance() {
         if (instance == null) {
             instance = new JsonMapper();
             instance.initialise();


### PR DESCRIPTION
Synchronized singleton getInstance for mapper.
Split arguments into variables.
Added unit test for Singletone break.